### PR TITLE
fix example for custom-fluid-width-and-height

### DIFF
--- a/custom-fluid-width-and-height/index.html
+++ b/custom-fluid-width-and-height/index.html
@@ -21,12 +21,12 @@ a:link:not(:hover) {
 <div id="container" style="position: relative; width: 50vw; height: 50vh;">
   <div id="chart" style="position: absolute; width: 100%; height: 100%;"></div>
 </div>
-<p>Credit: <a href="https://observablehq.com/@d3/bar-chart">Mike Bostock</a></p>
+<p>Credit: <a href="https://observablehq.com/@d3/quadtree-brush">Mike Bostock</a></p>
 
 <script type="module">
 
 import {Runtime, Inspector, Library} from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js";
-import notebook from "https://api.observablehq.com/@d3/bar-chart.js?v=3";
+import notebook from "https://api.observablehq.com/@d3/quadtree-brush.js?v=3";
 
 // To avoid the chart itself affecting the size of its container, the chart is
 // absolutely-positioned within the container element that determines the size.


### PR DESCRIPTION
The latest "@d3/bar-chart" no longer specifies height with a notebook cell, which breaks the example for "custom-fluid-width-and-height". Replaced it with "@d3/quadtree-brush", which specifies height in a way that demonstrates desired behavior.