### PR TITLE
Version-pin histogram for live data override

### DIFF
--- a/custom-live-data/README.md
+++ b/custom-live-data/README.md
@@ -30,9 +30,9 @@ main.redefine("data", library.Generators.observe(notify => {
 This is akin to doing
 
 ```js
-import {chart} with {myData as data} from "@d3/histogram"
+import {chart} with {myData as data} from "@d3/histogram@261"
 ```
 
-within a notebook. This example shows a [histogram](https://observablehq.com/@d3/histogram) where the data has been replaced to show a live histogram of recent Bitcoin transaction sizes via [Blockchain’s Websocket API](https://www.blockchain.com/api/api_websocket). Note that here `data` is redefined as a _generator_, and the chart re-renders whenever the data changes!
+within a notebook. This example shows a [histogram](https://observablehq.com/@d3/histogram@261) where the data has been replaced to show a live histogram of recent Bitcoin transaction sizes via [Blockchain’s Websocket API](https://www.blockchain.com/api/api_websocket). Note that here `data` is redefined as a _generator_, and the chart re-renders whenever the data changes!
 
 See also the [custom static data example](../custom-data/).

--- a/custom-live-data/index.html
+++ b/custom-live-data/index.html
@@ -18,12 +18,12 @@ a:link:not(:hover) {
 <p>This example demonstrates overriding the data used by an embedded chart to stream live data over a web socket.</p>
 
 <div id="chart" style="height: 488px;">Loading…</div>
-<p>Credit: <a href="https://observablehq.com/@d3/histogram">Mike Bostock</a> · Data: <a href="https://www.blockchain.com/api/api_websocket">Blockchain</a></p>
+<p>Credit: <a href="https://observablehq.com/@d3/histogram@261">Mike Bostock</a> · Data: <a href="https://www.blockchain.com/api/api_websocket">Blockchain</a></p>
 
 <script type="module">
 
 import {Runtime, Library, Inspector} from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js";
-import notebook from "https://api.observablehq.com/@d3/histogram.js?v=3";
+import notebook from "https://api.observablehq.com/@d3/histogram@261.js?v=3";
 
 // Instantiate the standard library so we can use Generators.observe (optional).
 const library = new Library();


### PR DESCRIPTION
[Eric in the D3 slack](https://d3js.slack.com/archives/C5534QP1V/p1641605690001600) was confused by this example because the D3 Charts rewrite broke it. This PR just pins to the old version. Not a great solution, I don't know. Some options:

- Override "alphabet" in the current version and conform to its shape. (Feels wrong.)
- Point to a different suitable generic D3 example that is unlikely to be rewritten as a component. (But histogram feels right for this data.)
- Fork the old histogram to an unlisted published notebook. (Not sure what we gain over version-pinning.)