### PR TITLE
v260 of bar chart fixes custom-fluid-width-and-height demo

### DIFF
--- a/custom-fluid-width-and-height/index.html
+++ b/custom-fluid-width-and-height/index.html
@@ -26,7 +26,7 @@ a:link:not(:hover) {
 <script type="module">
 
 import {Runtime, Inspector, Library} from "https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js";
-import notebook from "https://api.observablehq.com/@d3/bar-chart.js?v=3";
+import notebook from "https://api.observablehq.com/@d3/bar-chart@260.js?v=3";
 
 // To avoid the chart itself affecting the size of its container, the chart is
 // absolutely-positioned within the container element that determines the size.

--- a/react-create-react-app/package.json
+++ b/react-create-react-app/package.json
@@ -9,7 +9,7 @@
     "@testing-library/user-event": "^7.1.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-scripts": "3.4.1"
+    "react-scripts": "^5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Latest version of the bar-chart Observable notebook does not expose "height" but v260 does. This fixes the custom-fluid-width-and-height demo by pointing to v260